### PR TITLE
Add multi-module Maven project for Sonar and Jacoco setup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,4 +37,3 @@ jobs:
         run: mvn verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar 
           --batch-mode
           --define sonar.projectKey=rabestro_test-sonar-multimodules
-        

--- a/aggregate-report/pom.xml
+++ b/aggregate-report/pom.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>lv.id.jc</groupId>
+        <artifactId>test-sonar-multimodules</artifactId>
+        <version>1.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <packaging>pom</packaging>
+
+    <artifactId>aggregate-report</artifactId>
+    <dependencies>
+        <dependency>
+            <groupId>lv.id.jc</groupId>
+            <artifactId>module-code</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>lv.id.jc</groupId>
+            <artifactId>module-test</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>report</id>
+                        <goals>
+                            <goal>report-aggregate</goal>
+                        </goals>
+                        <phase>verify</phase>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/aggregate-report/pom.xml
+++ b/aggregate-report/pom.xml
@@ -8,7 +8,6 @@
         <groupId>lv.id.jc</groupId>
         <artifactId>test-sonar-multimodules</artifactId>
         <version>1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <packaging>pom</packaging>
 

--- a/module-code/pom.xml
+++ b/module-code/pom.xml
@@ -8,7 +8,6 @@
         <groupId>lv.id.jc</groupId>
         <artifactId>test-sonar-multimodules</artifactId>
         <version>1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>module-code</artifactId>

--- a/module-code/pom.xml
+++ b/module-code/pom.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>lv.id.jc</groupId>
+        <artifactId>test-sonar-multimodules</artifactId>
+        <version>1.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>module-code</artifactId>
+
+</project>

--- a/module-code/src/main/java/lv/id/jc/Foo.java
+++ b/module-code/src/main/java/lv/id/jc/Foo.java
@@ -1,0 +1,11 @@
+package lv.id.jc;
+
+public class Foo {
+    public int bar(int x, int y) {
+        int z = 0;
+        if ((x > 0) && (y > 0)) {
+            z = x;
+        }
+        return z;
+    }
+}

--- a/module-test/pom.xml
+++ b/module-test/pom.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>lv.id.jc</groupId>
+        <artifactId>test-sonar-multimodules</artifactId>
+        <version>1.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>module-test</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>lv.id.jc</groupId>
+            <artifactId>module-code</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.10.0</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/module-test/pom.xml
+++ b/module-test/pom.xml
@@ -8,7 +8,6 @@
         <groupId>lv.id.jc</groupId>
         <artifactId>test-sonar-multimodules</artifactId>
         <version>1.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>module-test</artifactId>

--- a/module-test/src/test/java/lv/id/jc/FooTest.java
+++ b/module-test/src/test/java/lv/id/jc/FooTest.java
@@ -1,0 +1,13 @@
+package lv.id.jc;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class FooTest {
+    @Test
+    public void testBar_BothNumbersPositive() {
+        Foo foo = new Foo();
+        int result = foo.bar(7, 3);
+        assertEquals(7, result, "Expected the value of x");
+    }
+}

--- a/module-test/src/test/java/lv/id/jc/FooTest.java
+++ b/module-test/src/test/java/lv/id/jc/FooTest.java
@@ -1,11 +1,12 @@
 package lv.id.jc;
 
 import org.junit.jupiter.api.Test;
-import static org.junit.jupiter.api.Assertions.*;
 
-public class FooTest {
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class FooTest {
     @Test
-    public void testBar_BothNumbersPositive() {
+    void testBar_BothNumbersPositive() {
         Foo foo = new Foo();
         int result = foo.bar(7, 3);
         assertEquals(7, result, "Expected the value of x");

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,16 @@
                     <artifactId>jacoco-maven-plugin</artifactId>
                     <version>0.8.11</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>3.2.2</version>
+                    <configuration>
+                        <includes>
+                            <include>**/*Test.java</include>
+                        </includes>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,9 @@
     </modules>
 
     <properties>
+        <sonar.organization>rabestro</sonar.organization>
+        <sonar.host.url>https://sonarcloud.io</sonar.host.url>
+        <sonar.language>java</sonar.language>
         <maven.compiler.release>17</maven.compiler.release>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,11 @@
         <sonar.organization>rabestro</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
         <sonar.language>java</sonar.language>
+        <sonar.coverage.jacoco.xmlReportPaths>
+            ${project.basedir}/target/site/jacoco-aggregate/jacoco.xml
+        </sonar.coverage.jacoco.xmlReportPaths>
+        <sonar.java.coveragePlugin>jacoco</sonar.java.coveragePlugin>
+
         <maven.compiler.release>17</maven.compiler.release>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>lv.id.jc</groupId>
+    <artifactId>test-sonar-multimodules</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>module-code</module>
+        <module>module-test</module>
+        <module>aggregate-report</module>
+    </modules>
+
+    <properties>
+        <maven.compiler.release>17</maven.compiler.release>
+    </properties>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.sonarsource.scanner.maven</groupId>
+                    <artifactId>sonar-maven-plugin</artifactId>
+                    <version>3.9.1.2184</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.jacoco</groupId>
+                    <artifactId>jacoco-maven-plugin</artifactId>
+                    <version>0.8.11</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+
+        <plugins>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -23,10 +23,14 @@
             ${project.basedir}/target/site/jacoco-aggregate/jacoco.xml
         </sonar.coverage.jacoco.xmlReportPaths>
         <sonar.java.coveragePlugin>jacoco</sonar.java.coveragePlugin>
-
+        <!-- Maven -->
         <maven.compiler.release>17</maven.compiler.release>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.testSource>17</maven.compiler.testSource>
+        <maven.compiler.testTarget>17</maven.compiler.testTarget>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,8 @@
 
     <properties>
         <maven.compiler.release>17</maven.compiler.release>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
     </properties>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,6 @@
         <sonar.coverage.jacoco.xmlReportPaths>
             ${project.basedir}/target/site/jacoco-aggregate/jacoco.xml
         </sonar.coverage.jacoco.xmlReportPaths>
-        <sonar.java.coveragePlugin>jacoco</sonar.java.coveragePlugin>
         <!-- Maven -->
         <maven.compiler.release>17</maven.compiler.release>
         <maven.compiler.source>17</maven.compiler.source>


### PR DESCRIPTION
This commit introduces a multi-module Maven-based project setup, with different modules for code, test code, and for generating aggregate reports. It modifies the project to accommodate a new setup where Sonar and Jacoco would be used for analysis and reporting. Two Maven modules 'module-code' and 'module-test' have been created along with test cases in them. Also, a 'aggregate-report' module is added to generate a consolidated report for better visibility. Some unneeded lines of code are removed from 'build.yml'. The changes are aiming at streamlining Static Code Analysis and Code Coverage processes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new functionality in the application with the addition of the `Foo` class.
- **Tests**
	- Added new test cases to ensure the correct operation of the `Foo` class when both input numbers are positive.
- **Chores**
	- Modified the build process configuration, removing the project key for SonarQube analysis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->